### PR TITLE
Add ability/training points tracking, bonuses concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ npm run test
 ## Done and todo:
 * [x] Basic stats
 * [x] Basic rune implementation
-* [ ] Ability points calculation
-* [ ] Skill point calculation/training
+* [x] Ability points calculation
+* [x] Training point calculation
+* [ ] Skills and training
 * [ ] Powers
 * [ ] Equipment (prerequisites and bonuses)
 * [ ] Effects
@@ -72,3 +73,5 @@ Contributions are welcome. Prior to contributing large changes, please have a qu
 that the change would be desirable.
 
 If you add new functionality, please add tests. Contributions are required to have the CI and all tests pass in the pull request prior to merge.
+
+Incoming changes have TSlint and Prettier run against them as well: if there are changes that are not checked in after Prettier/TSlint run then the pipeline will fail. Run `npm run build && npm run format && npm run lint && npm run pack && npm test` locally, fix any failures, and check in any changes prior to pushing.

--- a/__tests__/Character.test.ts
+++ b/__tests__/Character.test.ts
@@ -1,39 +1,128 @@
-import {Character} from '../src/Character'
+import {AbilityPointError, Character, LevelError} from '../src/Character'
 import {Rune} from '../src/Rune'
+import {StatLimitError} from '../src/Stats'
 
-test('fresh stats correct', () => {
-  const character = new Character()
+let character: Character
+beforeEach(() => (character = new Character()))
+
+test('fresh character ability points', () => {
   expect(character.stats.intelligence).toEqual(40)
   expect(character.stats.maxIntelligence).toEqual(100)
+  expect(character.getAbilityPoints()).toEqual(30)
+})
+
+test('leveled character ability points', () => {
+  character.setLevel(75)
+  expect(character.getAbilityPoints()).toEqual(236)
+})
+
+test('post creation ability points', () => {
+  character.setLevel(10)
+  expect(character.getAbilityPoints()).toEqual(75)
+})
+
+test('post creation bonus ability points', () => {
+  const bonusRuneJson: string = '{"bonuses":{"postCreationAbilityPoints": 20}}'
+  character.applyRune(Rune.fromJSON(JSON.parse(bonusRuneJson)))
+  character.setLevel(10)
+  expect(character.getAbilityPoints()).toEqual(95)
 })
 
 test('subtract points succeeds', () => {
-  const character = new Character()
   character.subtractIntelligence(1)
   expect(character.stats.intelligence).toEqual(39)
+  expect(character.getAbilityPoints()).toEqual(31)
 })
 
 test('subtract too many points fails', () => {
-  const character = new Character()
-  expect(() => character.subtractIntelligence(6)).toThrow()
+  expect(() => character.subtractIntelligence(6)).toThrow(StatLimitError)
+  expect(character.getAbilityPoints()).toEqual(30)
 })
 
 test('add points succeeds', () => {
-  const character = new Character()
   character.addIntelligence(1)
   expect(character.stats.intelligence).toEqual(41)
+  expect(character.getAbilityPoints()).toEqual(29)
+})
+
+test('add nonexistent points fails', () => {
+  character.addIntelligence(30)
+  expect(() => character.addIntelligence(1)).toThrow(AbilityPointError)
+  expect(character.getAbilityPoints()).toEqual(0)
 })
 
 test('add too many points fails', () => {
-  const character = new Character()
-  expect(() => character.addIntelligence(61)).toThrow()
+  character.setLevel(75)
+  expect(() => character.addIntelligence(61)).toThrow(StatLimitError)
 })
 
 test('adding rune changes stats', () => {
-  const character = new Character()
   const rune = Rune.fromJSON(JSON.parse('{"intelligenceModifier": 10}'))
   character.applyRune(rune)
 
   expect(character.stats.intelligence).toEqual(50)
   expect(character.stats.maxIntelligence).toEqual(100)
+})
+
+test('adding rune with point requirements succeeds', () => {
+  const rune = Rune.fromJSON(
+    JSON.parse('{"abilityPointCost":30,"intelligenceModifier":30}')
+  )
+  character.applyRune(rune)
+  expect(character.getAbilityPoints()).toEqual(0)
+  expect(character.stats.intelligence).toEqual(70)
+})
+
+test('adding rune with too many point requirements fails', () => {
+  const rune = Rune.fromJSON(
+    JSON.parse('{"abilityPointCost":31,"intelligenceModifier":31}')
+  )
+  expect(() => character.applyRune(rune)).toThrow(AbilityPointError)
+  expect(character.getAbilityPoints()).toEqual(30)
+  expect(character.stats.intelligence).toEqual(40)
+})
+
+test('backward level throws', () => {
+  character.setLevel(10)
+  expect(() => character.setLevel(9)).toThrow(LevelError)
+})
+
+test('too high level throws', () => {
+  expect(() => character.setLevel(76)).toThrow(LevelError)
+})
+
+test('apply creation only rune fails after creation', () => {
+  character.setLevel(2)
+  const rune = Rune.fromJSON(JSON.parse('{"isCreationOnlyRune":true}'))
+  expect(() => character.applyRune(rune)).toThrow(LevelError)
+})
+
+test('created character training points', () => {
+  character.endCreation()
+  expect(character.getTrainingPoints()).toEqual(36)
+})
+
+test('level 11 training points', () => {
+  character.endCreation()
+  character.setLevel(11)
+  expect(character.getTrainingPoints()).toEqual(46)
+})
+
+test('max level training points', () => {
+  character.setLevel(75)
+  expect(character.getTrainingPoints()).toEqual(588)
+})
+
+test('max level training points with 1-10 bonus', () => {
+  const runeJson = '{"bonuses":{"level1To10Trains": 1}}'
+  character.applyRune(Rune.fromJSON(JSON.parse(runeJson)))
+  character.setLevel(75)
+  expect(character.getTrainingPoints()).toEqual(588 + 10 - 1)
+})
+
+test('max level training points with 11-59 bonus', () => {
+  const runeJson = '{"bonuses":{"level11To59Trains": 1}}'
+  character.applyRune(Rune.fromJSON(JSON.parse(runeJson)))
+  character.setLevel(75)
+  expect(character.getTrainingPoints()).toEqual(588 + 59 - 10)
 })

--- a/__tests__/Util/PointUtils.test.ts
+++ b/__tests__/Util/PointUtils.test.ts
@@ -1,51 +1,41 @@
-import {PointUtils} from '../../src/Util/PointUtils'
+import {getTrainsForLevel} from '../../src/Util/PointUtils'
 import {Bonuses} from '../../src/Bonuses'
 
 test('train values without bonuses', () => {
   const emptyBonuses = new Bonuses()
-  expect(PointUtils.getTrainsForLevel(9, emptyBonuses)).toEqual(32)
-  expect(PointUtils.getTrainsForLevel(10, emptyBonuses)).toEqual(36)
-  expect(PointUtils.getTrainsForLevel(11, emptyBonuses)).toEqual(46)
-  expect(PointUtils.getTrainsForLevel(58, emptyBonuses)).toEqual(516)
-  expect(PointUtils.getTrainsForLevel(59, emptyBonuses)).toEqual(526)
-  expect(PointUtils.getTrainsForLevel(60, emptyBonuses)).toEqual(531)
-  expect(PointUtils.getTrainsForLevel(61, emptyBonuses)).toEqual(536)
-  expect(PointUtils.getTrainsForLevel(64, emptyBonuses)).toEqual(551)
-  expect(PointUtils.getTrainsForLevel(65, emptyBonuses)).toEqual(555)
-  expect(PointUtils.getTrainsForLevel(66, emptyBonuses)).toEqual(559)
-  expect(PointUtils.getTrainsForLevel(69, emptyBonuses)).toEqual(571)
-  expect(PointUtils.getTrainsForLevel(70, emptyBonuses)).toEqual(574)
-  expect(PointUtils.getTrainsForLevel(71, emptyBonuses)).toEqual(577)
-  expect(PointUtils.getTrainsForLevel(74, emptyBonuses)).toEqual(586)
-  expect(PointUtils.getTrainsForLevel(75, emptyBonuses)).toEqual(588)
+  expect(getTrainsForLevel(9, emptyBonuses)).toEqual(32)
+  expect(getTrainsForLevel(10, emptyBonuses)).toEqual(36)
+  expect(getTrainsForLevel(11, emptyBonuses)).toEqual(46)
+  expect(getTrainsForLevel(58, emptyBonuses)).toEqual(516)
+  expect(getTrainsForLevel(59, emptyBonuses)).toEqual(526)
+  expect(getTrainsForLevel(60, emptyBonuses)).toEqual(531)
+  expect(getTrainsForLevel(61, emptyBonuses)).toEqual(536)
+  expect(getTrainsForLevel(64, emptyBonuses)).toEqual(551)
+  expect(getTrainsForLevel(65, emptyBonuses)).toEqual(555)
+  expect(getTrainsForLevel(66, emptyBonuses)).toEqual(559)
+  expect(getTrainsForLevel(69, emptyBonuses)).toEqual(571)
+  expect(getTrainsForLevel(70, emptyBonuses)).toEqual(574)
+  expect(getTrainsForLevel(71, emptyBonuses)).toEqual(577)
+  expect(getTrainsForLevel(74, emptyBonuses)).toEqual(586)
+  expect(getTrainsForLevel(75, emptyBonuses)).toEqual(588)
 })
 
 test('train values with levels 1-10 bonuses', () => {
   const bonusesFor1Through10 = Bonuses.fromJSON(
     JSON.parse('{"level1To10Trains": 1}')
   )
-  expect(PointUtils.getTrainsForLevel(9, bonusesFor1Through10)).toEqual(32 + 8)
-  expect(PointUtils.getTrainsForLevel(10, bonusesFor1Through10)).toEqual(36 + 9)
-  expect(PointUtils.getTrainsForLevel(75, bonusesFor1Through10)).toEqual(
-    588 + 9
-  )
+  expect(getTrainsForLevel(9, bonusesFor1Through10)).toEqual(32 + 8)
+  expect(getTrainsForLevel(10, bonusesFor1Through10)).toEqual(36 + 9)
+  expect(getTrainsForLevel(75, bonusesFor1Through10)).toEqual(588 + 9)
 })
 
 test('train values with levels 11-59 bonuses', () => {
   const bonusesFor11Through59 = Bonuses.fromJSON(
     JSON.parse('{"level11To59Trains": 1}')
   )
-  expect(PointUtils.getTrainsForLevel(10, bonusesFor11Through59)).toEqual(36)
-  expect(PointUtils.getTrainsForLevel(11, bonusesFor11Through59)).toEqual(
-    46 + 1
-  )
-  expect(PointUtils.getTrainsForLevel(58, bonusesFor11Through59)).toEqual(
-    516 + 48
-  )
-  expect(PointUtils.getTrainsForLevel(59, bonusesFor11Through59)).toEqual(
-    526 + 49
-  )
-  expect(PointUtils.getTrainsForLevel(75, bonusesFor11Through59)).toEqual(
-    588 + 49
-  )
+  expect(getTrainsForLevel(10, bonusesFor11Through59)).toEqual(36)
+  expect(getTrainsForLevel(11, bonusesFor11Through59)).toEqual(46 + 1)
+  expect(getTrainsForLevel(58, bonusesFor11Through59)).toEqual(516 + 48)
+  expect(getTrainsForLevel(59, bonusesFor11Through59)).toEqual(526 + 49)
+  expect(getTrainsForLevel(75, bonusesFor11Through59)).toEqual(588 + 49)
 })

--- a/__tests__/Util/PointUtils.test.ts
+++ b/__tests__/Util/PointUtils.test.ts
@@ -1,0 +1,51 @@
+import {PointUtils} from '../../src/Util/PointUtils'
+import {Bonuses} from '../../src/Bonuses'
+
+test('train values without bonuses', () => {
+  const emptyBonuses = new Bonuses()
+  expect(PointUtils.getTrainsForLevel(9, emptyBonuses)).toEqual(32)
+  expect(PointUtils.getTrainsForLevel(10, emptyBonuses)).toEqual(36)
+  expect(PointUtils.getTrainsForLevel(11, emptyBonuses)).toEqual(46)
+  expect(PointUtils.getTrainsForLevel(58, emptyBonuses)).toEqual(516)
+  expect(PointUtils.getTrainsForLevel(59, emptyBonuses)).toEqual(526)
+  expect(PointUtils.getTrainsForLevel(60, emptyBonuses)).toEqual(531)
+  expect(PointUtils.getTrainsForLevel(61, emptyBonuses)).toEqual(536)
+  expect(PointUtils.getTrainsForLevel(64, emptyBonuses)).toEqual(551)
+  expect(PointUtils.getTrainsForLevel(65, emptyBonuses)).toEqual(555)
+  expect(PointUtils.getTrainsForLevel(66, emptyBonuses)).toEqual(559)
+  expect(PointUtils.getTrainsForLevel(69, emptyBonuses)).toEqual(571)
+  expect(PointUtils.getTrainsForLevel(70, emptyBonuses)).toEqual(574)
+  expect(PointUtils.getTrainsForLevel(71, emptyBonuses)).toEqual(577)
+  expect(PointUtils.getTrainsForLevel(74, emptyBonuses)).toEqual(586)
+  expect(PointUtils.getTrainsForLevel(75, emptyBonuses)).toEqual(588)
+})
+
+test('train values with levels 1-10 bonuses', () => {
+  const bonusesFor1Through10 = Bonuses.fromJSON(
+    JSON.parse('{"level1To10Trains": 1}')
+  )
+  expect(PointUtils.getTrainsForLevel(9, bonusesFor1Through10)).toEqual(32 + 8)
+  expect(PointUtils.getTrainsForLevel(10, bonusesFor1Through10)).toEqual(36 + 9)
+  expect(PointUtils.getTrainsForLevel(75, bonusesFor1Through10)).toEqual(
+    588 + 9
+  )
+})
+
+test('train values with levels 11-59 bonuses', () => {
+  const bonusesFor11Through59 = Bonuses.fromJSON(
+    JSON.parse('{"level11To59Trains": 1}')
+  )
+  expect(PointUtils.getTrainsForLevel(10, bonusesFor11Through59)).toEqual(36)
+  expect(PointUtils.getTrainsForLevel(11, bonusesFor11Through59)).toEqual(
+    46 + 1
+  )
+  expect(PointUtils.getTrainsForLevel(58, bonusesFor11Through59)).toEqual(
+    516 + 48
+  )
+  expect(PointUtils.getTrainsForLevel(59, bonusesFor11Through59)).toEqual(
+    526 + 49
+  )
+  expect(PointUtils.getTrainsForLevel(75, bonusesFor11Through59)).toEqual(
+    588 + 49
+  )
+})

--- a/src/Bonuses.ts
+++ b/src/Bonuses.ts
@@ -3,7 +3,7 @@ export class Bonuses {
   private level11To59Trains: number = 0
   private postCreationAbilityPoints: number = 0
 
-  static fromJSON(json: any): Bonuses {
+  static fromJSON(json: object): Bonuses {
     const bonuses = new Bonuses()
     return Object.assign(bonuses, json)
   }

--- a/src/Bonuses.ts
+++ b/src/Bonuses.ts
@@ -1,0 +1,30 @@
+export class Bonuses {
+  private level1To10Trains: number = 0
+  private level11To59Trains: number = 0
+  private postCreationAbilityPoints: number = 0
+
+  static fromJSON(json: any): Bonuses {
+    const bonuses = new Bonuses()
+    return Object.assign(bonuses, json)
+  }
+
+  /** combines bonuses from an incoming source with existing */
+  addBonuses(bonuses: Bonuses): void {
+    this.level1To10Trains = this.level1To10Trains + bonuses.level1To10Trains
+    this.level11To59Trains = this.level11To59Trains + bonuses.level11To59Trains
+    this.postCreationAbilityPoints =
+      this.postCreationAbilityPoints + bonuses.postCreationAbilityPoints
+  }
+
+  getLevel1To10Trains(): number {
+    return this.level1To10Trains
+  }
+
+  getLevel11To59Trains(): number {
+    return this.level11To59Trains
+  }
+
+  getPostCreationAbilityPoints(): number {
+    return this.postCreationAbilityPoints
+  }
+}

--- a/src/Character.ts
+++ b/src/Character.ts
@@ -1,56 +1,143 @@
 import {Stats} from './Stats'
 import {Rune} from './Rune'
+import {Bonuses} from './Bonuses'
+import {PointUtils} from './Util/PointUtils'
 
 export class Character {
-  stats: Stats = new Stats()
+  readonly stats: Stats = new Stats()
+  readonly bonuses: Bonuses = new Bonuses()
+  private abilityPoints: number = 30
+  private level: number = 1
+  private trainingPoints: number = 0
 
-  //#region add stats
+  //region add stats
 
   addDexterity(dexterityToAdd: number): void {
+    if (dexterityToAdd > this.abilityPoints) {
+      throw new AbilityPointError('not enough points remaining')
+    }
+    this.abilityPoints -= dexterityToAdd
     this.stats.dexterity += dexterityToAdd
   }
 
   addStrength(strengthToAdd: number): void {
+    if (strengthToAdd > this.abilityPoints) {
+      throw new AbilityPointError('not enough points remaining')
+    }
+    this.abilityPoints -= strengthToAdd
     this.stats.strength += strengthToAdd
   }
 
   addIntelligence(intelligenceToAdd: number): void {
+    if (intelligenceToAdd > this.abilityPoints) {
+      throw new AbilityPointError('not enough points remaining')
+    }
+    this.abilityPoints -= intelligenceToAdd
     this.stats.intelligence += intelligenceToAdd
   }
 
   addSpirit(spiritToAdd: number): void {
+    if (spiritToAdd > this.abilityPoints) {
+      throw new AbilityPointError('not enough points remaining')
+    }
+    this.abilityPoints -= spiritToAdd
     this.stats.spirit += spiritToAdd
   }
 
   addConstitution(constitutionToAdd: number): void {
+    if (constitutionToAdd > this.abilityPoints) {
+      throw new AbilityPointError('not enough points remaining')
+    }
+    this.abilityPoints -= constitutionToAdd
     this.stats.constitution += constitutionToAdd
   }
 
-  //#region subtract stats
+  //region subtract stats
 
   subtractDexterity(dexterityToSubtract: number): void {
     this.stats.dexterity -= dexterityToSubtract
+    this.abilityPoints += dexterityToSubtract
   }
 
   subtractStrength(strengthToSubtract: number): void {
     this.stats.strength -= strengthToSubtract
+    this.abilityPoints += strengthToSubtract
   }
 
   subtractIntelligence(intelligenceToSubtract: number): void {
     this.stats.intelligence -= intelligenceToSubtract
+    this.abilityPoints += intelligenceToSubtract
   }
 
   subtractSpirit(spiritToSubtract: number): void {
     this.stats.spirit -= spiritToSubtract
+    this.abilityPoints += spiritToSubtract
   }
 
   subtractConstitution(constitutionToSubtract: number): void {
     this.stats.constitution -= constitutionToSubtract
+    this.abilityPoints += constitutionToSubtract
   }
 
-  //#region runes
+  //region runes
 
   applyRune(rune: Rune): void {
+    if (this.abilityPoints - rune.getAbilityPointCost() < 0) {
+      throw new AbilityPointError('too few points to apply rune')
+    }
+
+    if (rune.getIsCreationOnlyRune() && this.level > 1) {
+      throw new LevelError('cannot apply creation runes after creation')
+    }
+
+    this.abilityPoints -= rune.getAbilityPointCost()
+    this.bonuses.addBonuses(rune.getBonuses())
     this.stats.applyRune(rune)
   }
+
+  //region levels and points
+
+  endCreation(): void {
+    this.setLevel(10)
+  }
+
+  setLevel(level: number): void {
+    if (level < this.level) {
+      throw new LevelError('level cannot be less than current level')
+    }
+
+    if (level > 75) {
+      throw new LevelError('provided level is greater than max level')
+    }
+
+    if (this.level == 1) {
+      this._endCreation()
+    }
+
+    this.abilityPoints += PointUtils.getAbilityPointsForLevelIncreaase(
+      this.level,
+      level
+    )
+    this.trainingPoints += PointUtils.getTrainsForLevelIncrease(
+      this.level,
+      level,
+      this.bonuses
+    )
+    this.level = level
+  }
+
+  private _endCreation() {
+    this.abilityPoints += this.bonuses.getPostCreationAbilityPoints()
+  }
+
+  getAbilityPoints(): number {
+    return this.abilityPoints
+  }
+
+  getTrainingPoints(): number {
+    return this.trainingPoints
+  }
 }
+
+export class AbilityPointError extends Error {}
+export class LevelError extends Error {}

--- a/src/Character.ts
+++ b/src/Character.ts
@@ -1,7 +1,10 @@
 import {Stats} from './Stats'
 import {Rune} from './Rune'
 import {Bonuses} from './Bonuses'
-import {PointUtils} from './Util/PointUtils'
+import {
+  getTrainsForLevelIncrease,
+  getAbilityPointsForLevelIncrease
+} from './Util/PointUtils'
 
 export class Character {
   readonly stats: Stats = new Stats()
@@ -110,15 +113,12 @@ export class Character {
       throw new LevelError('provided level is greater than max level')
     }
 
-    if (this.level == 1) {
+    if (this.level === 1) {
       this._endCreation()
     }
 
-    this.abilityPoints += PointUtils.getAbilityPointsForLevelIncreaase(
-      this.level,
-      level
-    )
-    this.trainingPoints += PointUtils.getTrainsForLevelIncrease(
+    this.abilityPoints += getAbilityPointsForLevelIncrease(this.level, level)
+    this.trainingPoints += getTrainsForLevelIncrease(
       this.level,
       level,
       this.bonuses
@@ -126,7 +126,7 @@ export class Character {
     this.level = level
   }
 
-  private _endCreation() {
+  private _endCreation(): void {
     this.abilityPoints += this.bonuses.getPostCreationAbilityPoints()
   }
 

--- a/src/Rune.ts
+++ b/src/Rune.ts
@@ -1,4 +1,13 @@
+import {Bonuses} from './Bonuses'
+
+interface RuneJson {
+  bonuses: any
+}
+
 export class Rune {
+  private abilityPointCost: number = 0
+  private isCreationOnlyRune: boolean = false
+
   private maxDexterityModifier: number = 0
   private dexterityModifier: number = 0
   private maxStrengthModifier: number = 0
@@ -10,9 +19,22 @@ export class Rune {
   private maxConstitutionModifier: number = 0
   private constitutionModifier: number = 0
 
-  static fromJSON(json: object): Rune {
+  private bonuses: Bonuses = new Bonuses()
+
+  static fromJSON(json: RuneJson): Rune {
     const rune = new Rune()
-    return Object.assign(rune, json)
+
+    return Object.assign(rune, json, {
+      bonuses: Bonuses.fromJSON(json.bonuses)
+    })
+  }
+
+  getAbilityPointCost(): number {
+    return this.abilityPointCost
+  }
+
+  getIsCreationOnlyRune(): boolean {
+    return this.isCreationOnlyRune
   }
 
   getDexterityModifier(): number {
@@ -53,5 +75,9 @@ export class Rune {
 
   getMaxConstitutionModifier(): number {
     return this.maxConstitutionModifier
+  }
+
+  getBonuses(): Bonuses {
+    return this.bonuses
   }
 }

--- a/src/Rune.ts
+++ b/src/Rune.ts
@@ -1,7 +1,7 @@
 import {Bonuses} from './Bonuses'
 
 interface RuneJson {
-  bonuses: any
+  bonuses: object
 }
 
 export class Rune {

--- a/src/Stats.ts
+++ b/src/Stats.ts
@@ -26,7 +26,9 @@ export class Stats {
   }
   set dexterity(value: number) {
     if (value < this.minDexterity || value > this.maxDexterity) {
-      throw new Error('new value not within allowed limits for dexterity')
+      throw new StatLimitError(
+        'new value not within allowed limits for dexterity'
+      )
     }
     this._dexterity = value
   }
@@ -36,7 +38,9 @@ export class Stats {
   }
   set strength(value: number) {
     if (value < this.minStrength || value > this.maxStrength) {
-      throw new Error('new value not within allowed limits for strength')
+      throw new StatLimitError(
+        'new value not within allowed limits for strength'
+      )
     }
     this._strength = value
   }
@@ -46,7 +50,9 @@ export class Stats {
   }
   set intelligence(value: number) {
     if (value < this.minIntelligence || value > this.maxIntelligence) {
-      throw new Error('new value not within allowed limits for intelligence')
+      throw new StatLimitError(
+        'new value not within allowed limits for intelligence'
+      )
     }
     this._intelligence = value
   }
@@ -56,7 +62,7 @@ export class Stats {
   }
   set spirit(value: number) {
     if (value < this.minSpirit || value > this.maxSpirit) {
-      throw new Error('new value not within allowed limits for spirit')
+      throw new StatLimitError('new value not within allowed limits for spirit')
     }
     this._spirit = value
   }
@@ -66,7 +72,9 @@ export class Stats {
   }
   set constitution(value: number) {
     if (value < this.minConstitution || value > this.maxConstitution) {
-      throw new Error('new value not within allowed limits for constitution')
+      throw new StatLimitError(
+        'new value not within allowed limits for constitution'
+      )
     }
     this._constitution = value
   }
@@ -84,3 +92,5 @@ export class Stats {
     this.constitution += rune.getConstitutionModifier()
   }
 }
+
+export class StatLimitError extends Error {}

--- a/src/Util/PointUtils.ts
+++ b/src/Util/PointUtils.ts
@@ -1,0 +1,64 @@
+import {Bonuses} from '../Bonuses'
+import {LevelError} from '../Character'
+
+export class PointUtils {
+  public static getTrainsForLevelIncrease(
+    oldLevel: number,
+    newLevel: number,
+    bonuses: Bonuses
+  ): number {
+    const currentTrainsForLevel = this.getTrainsForLevel(oldLevel, bonuses)
+    const newTrainsForLevel = this.getTrainsForLevel(newLevel, bonuses)
+    return newTrainsForLevel - currentTrainsForLevel
+  }
+
+  public static getAbilityPointsForLevelIncreaase(
+    oldLevel: number,
+    newLevel: number
+  ): number {
+    return (
+      this.getAbilityPointsForLevel(newLevel) -
+      this.getAbilityPointsForLevel(oldLevel)
+    )
+  }
+
+  public static getAbilityPointsForLevel(level: number): number {
+    if (level < 20) {
+      return (level - 1) * 5
+    } else if (level < 30) {
+      return 90 + (level - 19) * 4
+    } else if (level < 40) {
+      return 130 + (level - 29) * 3
+    } else if (level < 50) {
+      return 160 + (level - 39) * 2
+    } else {
+      return 180 + (level - 49)
+    }
+  }
+
+  public static getTrainsForLevel(level: number, bonuses: Bonuses): number {
+    let bonusTrains: number = 0
+
+    const levelsForLowerBonus: number = Math.min(level, 10)
+    bonusTrains += (levelsForLowerBonus - 1) * bonuses.getLevel1To10Trains()
+
+    const levelsForUpperBonus: number = Math.min(59, Math.max(level, 10)) - 10
+    bonusTrains += levelsForUpperBonus * bonuses.getLevel11To59Trains()
+
+    if (level <= 10) {
+      return (level - 1) * 4 + bonusTrains
+    } else if (level < 60) {
+      return 36 + (level - 10) * 10 + bonusTrains
+    } else if (level < 65) {
+      return 526 + (level - 59) * 5 + bonusTrains
+    } else if (level < 70) {
+      return 551 + (level - 64) * 4 + bonusTrains
+    } else if (level < 75) {
+      return 571 + (level - 69) * 3 + bonusTrains
+    } else if (level == 75) {
+      return 588 + bonusTrains
+    }
+
+    throw new LevelError('unsupported level') // appease the compiler
+  }
+}

--- a/src/Util/PointUtils.ts
+++ b/src/Util/PointUtils.ts
@@ -1,64 +1,59 @@
 import {Bonuses} from '../Bonuses'
 import {LevelError} from '../Character'
 
-export class PointUtils {
-  public static getTrainsForLevelIncrease(
-    oldLevel: number,
-    newLevel: number,
-    bonuses: Bonuses
-  ): number {
-    const currentTrainsForLevel = this.getTrainsForLevel(oldLevel, bonuses)
-    const newTrainsForLevel = this.getTrainsForLevel(newLevel, bonuses)
-    return newTrainsForLevel - currentTrainsForLevel
+export function getTrainsForLevelIncrease(
+  oldLevel: number,
+  newLevel: number,
+  bonuses: Bonuses
+): number {
+  const currentTrainsForLevel = getTrainsForLevel(oldLevel, bonuses)
+  const newTrainsForLevel = getTrainsForLevel(newLevel, bonuses)
+  return newTrainsForLevel - currentTrainsForLevel
+}
+
+export function getAbilityPointsForLevelIncrease(
+  oldLevel: number,
+  newLevel: number
+): number {
+  return getAbilityPointsForLevel(newLevel) - getAbilityPointsForLevel(oldLevel)
+}
+
+export function getTrainsForLevel(level: number, bonuses: Bonuses): number {
+  let bonusTrains = 0
+
+  const levelsForLowerBonus = Math.min(level, 10)
+  bonusTrains += (levelsForLowerBonus - 1) * bonuses.getLevel1To10Trains()
+
+  const levelsForUpperBonus = Math.min(59, Math.max(level, 10)) - 10
+  bonusTrains += levelsForUpperBonus * bonuses.getLevel11To59Trains()
+
+  if (level <= 10) {
+    return (level - 1) * 4 + bonusTrains
+  } else if (level < 60) {
+    return 36 + (level - 10) * 10 + bonusTrains
+  } else if (level < 65) {
+    return 526 + (level - 59) * 5 + bonusTrains
+  } else if (level < 70) {
+    return 551 + (level - 64) * 4 + bonusTrains
+  } else if (level < 75) {
+    return 571 + (level - 69) * 3 + bonusTrains
+  } else if (level === 75) {
+    return 588 + bonusTrains
   }
 
-  public static getAbilityPointsForLevelIncreaase(
-    oldLevel: number,
-    newLevel: number
-  ): number {
-    return (
-      this.getAbilityPointsForLevel(newLevel) -
-      this.getAbilityPointsForLevel(oldLevel)
-    )
-  }
+  throw new LevelError('unsupported level') // appease the compiler
+}
 
-  public static getAbilityPointsForLevel(level: number): number {
-    if (level < 20) {
-      return (level - 1) * 5
-    } else if (level < 30) {
-      return 90 + (level - 19) * 4
-    } else if (level < 40) {
-      return 130 + (level - 29) * 3
-    } else if (level < 50) {
-      return 160 + (level - 39) * 2
-    } else {
-      return 180 + (level - 49)
-    }
-  }
-
-  public static getTrainsForLevel(level: number, bonuses: Bonuses): number {
-    let bonusTrains: number = 0
-
-    const levelsForLowerBonus: number = Math.min(level, 10)
-    bonusTrains += (levelsForLowerBonus - 1) * bonuses.getLevel1To10Trains()
-
-    const levelsForUpperBonus: number = Math.min(59, Math.max(level, 10)) - 10
-    bonusTrains += levelsForUpperBonus * bonuses.getLevel11To59Trains()
-
-    if (level <= 10) {
-      return (level - 1) * 4 + bonusTrains
-    } else if (level < 60) {
-      return 36 + (level - 10) * 10 + bonusTrains
-    } else if (level < 65) {
-      return 526 + (level - 59) * 5 + bonusTrains
-    } else if (level < 70) {
-      return 551 + (level - 64) * 4 + bonusTrains
-    } else if (level < 75) {
-      return 571 + (level - 69) * 3 + bonusTrains
-    } else if (level == 75) {
-      return 588 + bonusTrains
-    }
-
-    throw new LevelError('unsupported level') // appease the compiler
+export function getAbilityPointsForLevel(level: number): number {
+  if (level < 20) {
+    return (level - 1) * 5
+  } else if (level < 30) {
+    return 90 + (level - 19) * 4
+  } else if (level < 40) {
+    return 130 + (level - 29) * 3
+  } else if (level < 50) {
+    return 160 + (level - 39) * 2
+  } else {
+    return 180 + (level - 49)
   }
 }


### PR DESCRIPTION
This PR adds ability and training points to the character. Since runes can grant bonuses to these, we also have to start on the bonuses work as well. In order to test training and ability points, the level concept also had to be added to the character. As the character levels, they receive training points and ability points according to set schedules. Human race runes add 20 ability points after creation time, as well as granting bonus trains for levels 1-59. Mage/Healer class runes add bonus trains for levels 1-59 as well. Runes can now also cost ability points to apply. 

Bonuses are tracked on the character, and when adding a rune the incoming bonuses are added to the existing bonuses. In the future, there will be many sources of bonuses (Rune, Effect, Equipment) and the application method will probably be generalized.

I also added the creation-only concept for runes that can only be taken at creation time.